### PR TITLE
Fixed the ordering of the X and Z matrices when fitting a bernoulli longitudinal submodel

### DIFF
--- a/rstanjm.Rproj
+++ b/rstanjm.Rproj
@@ -13,5 +13,5 @@ RnwWeave: knitr
 LaTeX: pdfLaTeX
 
 BuildType: Package
-PackageInstallArgs: --no-multiarch --with-keep.source --preclean
+PackageInstallArgs: --no-multiarch --with-keep.source --precleanO
 PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
Estimates from the univariate joint model with a bernoulli marker are
now correct