### PR TITLE
Fixed two bugs, detailed below

### DIFF
--- a/R/ps_data.R
+++ b/R/ps_data.R
@@ -110,8 +110,10 @@ ps_data <-
     newdata <- cbind(unclass(newdata[[1]]), newdata)
     if (resp_type == "right") {
       newdata <- data.table::data.table(newdata, key = c(id_var, "time"))
+      newdata[["time"]] <- as.numeric(newdata[["time"]])
     } else if (resp_type == "counting") {
       newdata <- data.table::data.table(newdata, key = c(id_var, "start"))
+      newdata[["start"]] <- as.numeric(newdata[["start"]])
     } else {
       stop("Bug found: newdataEvent was set to NULL, but the model ",
            "frame collected from the original model doesn't appear to ",

--- a/exec/jm.stan
+++ b/exec/jm.stan
@@ -1,19 +1,19 @@
 /*
-    This file is part of rstanarm.
+    This file is part of rstanjm.
     Copyright (C) 2015, 2016 Trustees of Columbia University
     
-    rstanarm is free software: you can redistribute it and/or modify
+    rstanjm is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    rstanarm is distributed in the hope that it will be useful,
+    rstanjm is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with rstanarm.  If not, see <http://www.gnu.org/licenses/>.
+    along with rstanjm.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 functions {


### PR DESCRIPTION
Made sure that model frame time variable is numeric before data.table
merge. It was converting the quadrature times to integers if the time
variable in the original model frame was integer and not numeric.

Also fixed the Zqmerge and Zqmerge_eps design matrices in stan_jm so
that they are subjected to the pad_reTrms function, just like the Z
design matrix is. This ensures that the matrices are of the correct size
before passing them to Stan. They were the wrong size before this bug
fix, and therefore the multivariate joint model was returning incorrect
estimates for the second marker.